### PR TITLE
Updated docs to reflect returning a function

### DIFF
--- a/docs/can-stream.md
+++ b/docs/can-stream.md
@@ -1,132 +1,25 @@
-@module {Object} can-stream can-stream
+@module {function} can-stream can-stream
 @parent can-ecosystem
-@group can-stream.fns 4 Methods
+@group can-stream.types types
 @package ../package.json
 
-@description Exports a function that takes a can-stream interface (like [can-stream-kefir](https://github.com/canjs/can-stream-kefir)) and uses it internally to provide the stream functionality.
+@description Create useful stream methods from a minimal stream wrapper implementation.
 
-@type {Object}
+@signature `canStream(streamImplementation)`
 
-  The `can-stream` module exports a function that takes a can-stream interface and returns an object with the following methods:
+Exports a function that takes a [can-stream.types.streamImplementation] (like [can-stream-kefir]) and uses it internally to provide several useful string methods.
 
-- `.toStream(observable, propAndOrEvent[,event])`
-- `.toStreamFromProperty(property)`
-- `.toStreamFromEvent(property)`
-- `.toCompute(makeStream(setStream), context):compute`
+@param {can-stream.types.streamImplementation} streamImplementation A [can-stream.types.streamImplementation] object that implements the `toStream` and `toCompute` methods for a stream library.
 
+@return {can-stream.types.streamInterface} An object that has the following methods:
+
+- .toStream(observable, propAndOrEvent[,event])
+- .toStreamFromProperty(property)
+- .toStreamFromEvent(property)
+- .toCompute([can-stream.types.makeStream makeStream(setStream)], context):compute
 
 @body
 
-## Usage
+## Use
 
-The [can-stream] method has shorthands for all of the other methods:
-
-```
-var canStream = require("can-stream");
-
-var canStreaming = canStream(canStreamingInterface);
-
-canStreaming.toStream(compute)                    //-> stream
-canStreaming.toStream(map, "eventName")           //-> stream
-canStreaming.toStream(map, ".propName")           //-> stream
-canStreaming.toStream(map, ".propName eventName") //-> stream
-```
-
-For example:
-
-__Converting a compute to a stream__
-
-```js
-var canCompute = require("can-compute");
-var canStreamKefir = require("can-stream-kefir");
-var canStream = require("can-stream");
-
-var canStreaming = canStream(canStreamKefir);
-
-var compute = canCompute(0);
-var stream = canStreaming.toStream(compute);
-
-stream.onValue(function(newVal){
-	console.log(newVal);
-});
-
-compute(1);
-//-> console.logs 1
-```
-
-__Converting an event to a stream__
-
-```js
-var DefineList = require('can-define/list/list');
-var canStreamKefir = require("can-stream-kefir");
-var canStream = require("can-stream");
-
-var canStreaming = canStream(canStreamKefir);
-
-var hobbies = new DefineList(["js","kayaking"]);
-
-var changeCount = canStreaming.toStream(obs, "length").scan(function(prev){
-	return prev + 1;
-}, 0);
-changeCount.onValue(function(event) {
-	console.log(event);
-});
-
-hobbies.push("bball")
-//-> console.logs {type: "add", args: [2,["bball"]]}
-hobbies.shift()
-//-> console.logs {type: "remove", args: [0,["js"]]}
-```
-
-__Converting a property value to a stream__
-
-```js
-var canStreamKefir = require("can-stream-kefir");
-var canStream = require("can-stream");
-
-var canStreaming = canStream(canStreamKefir);
-var DefineMap = require("can-define/map/map");
-
-var person = new DefineMap({
-	first: "Justin",
-	last: "Meyer"
-});
-
-var first = canStreaming.toStream(person, '.first'),
-	last = canStreaming.toStream(person, '.last');
-
-var fullName = Kefir.combine(first, last, function(first, last){
-	return first + last;
-});
-
-fullName.onValue(function(newVal){
-	console.log(newVal);
-});
-
-map.first = "Payal"
-//-> console.logs "Payal Meyer"
-```
-
-__Converting an event on a nested object into a stream__
-
-```js
-var canStreamKefir = require("can-stream-kefir");
-var canStream = require("can-stream");
-
-var canStreaming = canStream(canStreamKefir);
-var DefineMap = require("can-define/map/map");
-var DefineList = require("can-define/list/list");
-
-var me = new DefineMap({
-	todos: ["mow lawn"]
-});
-
-var addStream = canStreaming.toStream(me, ".todos add");
-
-addStream.onValue(function(event){
-	console.log(event);
-});
-
-map.todos.push("do dishes");
-//-> console.logs {type: "add", args: [1,["do dishes"]]}
-```
+See [can-stream-kefir] for an example.

--- a/docs/implementation.toCompute.md
+++ b/docs/implementation.toCompute.md
@@ -1,0 +1,58 @@
+@function can-stream/type/implementation.toCompute toCompute
+@parent can-stream.types.streamImplementation
+
+@description Creates a [can-compute.computed] from a stream generator function.
+
+@signature `toCompute( makeStream(setStream), [context] )`
+
+This returns a [can-compute.computed] that when [can-compute.computed.on bound]
+takes on the value of the stream returned by `makeStream`.  `makeStream`
+is called with:
+
+ - its `this` as the `context`, and
+ - `setStream` which is a stream of values set on the returned compute (ex: `compute(5)`).
+
+This is used to create computes from streams.
+
+```js
+var count = Kefir.sequentially(1000, [1, 2]);
+
+var myCompute = canStream.toCompute(function(setStream){
+	return setStream.merge(count);
+});
+
+// listen to the compute for it to have a value
+myCompute.on("change", function(){})
+
+myCompute("A")
+
+// immediate value
+myCompute() //-> "A"
+
+// 1000ms later
+myCompute() //-> 1
+
+// 1000ms later
+myCompute() //-> 2
+```
+
+  @param {function(Stream):Stream} makeStream(setStream) A stream generator
+  function.  This function takes the stream of set values, and typically other streams
+  and manipulates them into the final returned output stream.  The output stream's
+  values are used as the value of the returned [can-compute.computed].
+
+  The `setStream` is the stream of values set on the returned compute. In the following example, `setStream` will emit the values `1` and then `2`.
+
+  ```js
+  var returnedCompute = canStream.toCompute(function(setStream){
+   return setStream;
+  });
+  returnedCompute(1);
+  returnedCompute(2);
+  ```
+
+  @param {Object} [context] An optional context which will be the `this` of `makeStream`.
+
+  @return {can-compute.computed} A compute that when read will return the value of
+  the stream returned by `setStream`.  When the compute is written to, it will
+  update `setStream`.

--- a/docs/implementation.toStream.md
+++ b/docs/implementation.toStream.md
@@ -1,0 +1,8 @@
+@function can-stream/type/implementation.toStream toStream
+@parent can-stream.types.streamImplementation
+
+@description Create a stream from an observable.
+
+@signature `toStream( compute )`
+
+@param {Compute} compute An [can-compute] object

--- a/docs/interface.toCompute.md
+++ b/docs/interface.toCompute.md
@@ -1,7 +1,7 @@
-@function can-stream.toCompute toCompute
-@parent can-stream.fns
+@function can-stream/type/interface.toCompute toCompute
+@parent can-stream.types.streamInterface
 
-@description Creates a [can-compute.computed] from a stream generator function.
+@description Create a [can-compute.computed] from a stream generator function.
 
 @signature `canStream.toCompute( makeStream(setStream), [context] )`
 

--- a/docs/interface.toStream.md
+++ b/docs/interface.toStream.md
@@ -1,6 +1,5 @@
-@function can-stream.toStream toStream
-@parent can-stream.fns
-
+@function can-stream/type/interface.toStream toStream
+@parent can-stream.types.streamInterface
 
 @description Provides a shorthand for creating a stream from observable objects, properties and
 events.

--- a/docs/interface.toStreamFromEvent.md
+++ b/docs/interface.toStreamFromEvent.md
@@ -1,6 +1,5 @@
-@function can-stream.toStreamFromEvent toStreamFromEvent
-@parent can-stream.fns
-
+@function can-stream/type/interface.toStreamFromEvent toStreamFromEvent
+@parent can-stream.types.streamInterface
 
 @description Creates a stream on a {Observable} object that gets updated whenever the event occurs on the observable object.
 

--- a/docs/interface.toStreamFromProperty.md
+++ b/docs/interface.toStreamFromProperty.md
@@ -1,6 +1,5 @@
-@function can-stream.toStreamFromProperty toStreamFromProperty
-@parent can-stream.fns
-
+@function can-stream/type/interface.toStreamFromProperty toStreamFromProperty
+@parent can-stream.types.streamInterface
 
 @description Creates a stream on a {Observable} object that gets updated whenever the property value on the observable changes.
 

--- a/docs/types.makeStream.md
+++ b/docs/types.makeStream.md
@@ -1,0 +1,17 @@
+@typedef {function} can-stream.types.makeStream makeStream
+@parent can-stream.types
+
+@description This function takes a stream whose values are bound to the returned [can-compute.computed].
+
+@signature `makeStream(setStream)`
+
+```js
+var Kefir = require('kefir');
+var count = Kefir.sequentially(1000, [1, 2]);
+
+var myCompute = canStream.toCompute(function(setStream) {
+	return setStream.merge(count);
+});
+```
+
+@param {Stream} setStream A stream to bind to the returned [can-compute.computed].

--- a/docs/types.streamImplementation.md
+++ b/docs/types.streamImplementation.md
@@ -1,0 +1,42 @@
+@typedef {Object} can-stream.types.streamImplementation StreamImplementation
+@parent can-stream.types
+
+@description Export an object with a minimal implementation of `toStream` and `toCompute` methods specific to a streaming library like [Kefir](https://rpominov.github.io/kefir/)
+
+@type {Object}
+  An object with `toStream` and `toCompute` methods.
+
+```js
+var streamImplementation = {
+	toStream: function(compute){
+		return MAKE_THE_STREAM_FROM_A_COMPUTE(compute);
+	},
+	toCompute: function(makeStream, context){
+		var setStream = MAKE_A_SETTABLE_STREAM_THAT_IS_SET_WHEN_COMPUTE_IS_SET();
+		var stream = makeStream.call(context, setStream);
+
+		var compute = MAKE_COMPUTE_TO_HAVE_VALUE_FROM_stream_AND_SET_TO_setStream;
+
+		return compute;
+	}
+};
+
+var canStream = require("can-stream");
+
+var streamInterface = canStream(streamImplementation);
+
+var map = new DefineMap({name: "John"});
+streamInterface(map, ".name") //-> an instance of the stream library.
+
+module.exports = streamInterface;
+```
+
+	@option {can-stream/type/implementation.toStream} toStream
+
+  @option {can-stream/type/implementation.toCompute} toCompute
+
+@body
+
+## Use
+
+See [can-stream-kefir] for example implementation.

--- a/docs/types.streamInterface.md
+++ b/docs/types.streamInterface.md
@@ -1,0 +1,20 @@
+@typedef {function} can-stream.types.streamInterface streamInterface
+@parent can-stream.types
+
+@description Stream interface function returned from [can-stream]
+
+@signature `streamInterface( observable, propAndOrEvent[,event] )`
+
+The stream interface function returned from [can-stream] that has the following property methods:
+
+- .toStream(observable, propAndOrEvent[,event])
+- .toStreamFromProperty(property)
+- .toStreamFromEvent(property)
+- .toCompute([can-stream.types.makeStream makeStream(setStream)], context):compute
+
+@param {Object} observable An observable object
+
+@param {String} property A property of the observable object prepended with `.`
+
+@param {String} [event] An optional event name of the observable object
+


### PR DESCRIPTION
Changed docs to reflect `can-stream` taking a `streamImplementation` and returning a `streamInterface` function.

- Added `types` docs for `makeStream`, `streamImplementation`, `streamInterface`
- Added `toStream` and `toCompute` implementation method documentation
- Moved methods to be nested under `streamInterface`

Still need to redo examples in the `streamInterface` methods after function is returned.