### PR TITLE
Set the default return to be the toStream function

### DIFF
--- a/can-stream.js
+++ b/can-stream.js
@@ -29,7 +29,7 @@ var toComputeFromEvent = function(observable, eventName){
 
 var STREAM = function(canStreamInterface) {
 
-	var canStream = function() {};
+	var canStream;
 
 	var toStreamFromProperty = function(obs, propName) {
 		return canStreamInterface.toStream(compute(obs, propName));

--- a/can-stream.js
+++ b/can-stream.js
@@ -28,13 +28,14 @@ var toComputeFromEvent = function(observable, eventName){
 
 
 var STREAM = function(canStreamInterface) {
-	var canStream = {};
 
-	canStream.toStreamFromProperty = function(obs, propName) {
+	var canStream = function() {};
+
+	var toStreamFromProperty = function(obs, propName) {
 		return canStreamInterface.toStream(compute(obs, propName));
 	};
 
-	canStream.toStreamFromEvent = function() {
+	var toStreamFromEvent = function() {
 		var obs = arguments[0];
 		var eventName, propName, lastValue, internalCompute;
 
@@ -91,7 +92,7 @@ var STREAM = function(canStreamInterface) {
 	};
 
 	//.toStream(observable, propAndOrEvent[,event])
-	canStream.toStream = function() {
+	var toStream = function() {
 
 		if(arguments.length === 1) {
 			//we expect it to be a compute:
@@ -119,14 +120,19 @@ var STREAM = function(canStreamInterface) {
 		return undefined;
 	};
 
-	canStream.toCompute = function(makeStream, context) {
+	var toCompute = function(makeStream, context) {
 		var args = makeArray(arguments);
 		return canStreamInterface.toCompute.apply(this, args);
 	};
 
+	canStream = toStream;
+	canStream.toStream = canStream;
+	canStream.toStreamFromProperty = toStreamFromProperty;
+	canStream.toStreamFromEvent = toStreamFromEvent;
+	canStream.toCompute = toCompute;
+
 	return canStream;
 };
 STREAM.toComputeFromEvent = toComputeFromEvent;
-
 
 module.exports = namespace.stream = STREAM;

--- a/can-stream_test.js
+++ b/can-stream_test.js
@@ -6,12 +6,36 @@ var canStream = require('can-stream');
 
 QUnit.module('can-stream');
 
+test('Resolves to "toStream" function', function() {
+	var c = compute(0);
+	var obj;
+	var streamInterface;
+
+	var streamImplementation = {
+		toStream: function(observable, propOrEvent) {
+			QUnit.equal(c, observable);
+			return obj = {
+				onValue: function(callback) {
+					c.on('change', function(evnt, newVal, oldVal) {
+						callback(newVal);
+					});
+					callback(c()); //initial value;
+				}
+			};
+		},
+		toCompute: function(makeStream, context) {}
+	};
+	streamInterface = canStream(streamImplementation);
+
+	var stream = streamInterface(c);
+	QUnit.equal(obj, stream);
+
+});
+
 test('Compute changes can be streamed', function () {
 	var c = compute(0);
 	var obj;
 	var canStreaming;
-
-
 
 	var canStreamInterface = {
 		toStream: function(observable, propOrEvent) {
@@ -140,7 +164,6 @@ test('Stream on a property val - toStreamFromProperty', function(){
 		QUnit.equal(val, expected);
 	});
 
-
 	expected = "foobar";
 	map.foo = "foobar";
 
@@ -171,7 +194,6 @@ test('Event streams fire change events', function () {
 	var canStreaming = canStream(canStreamInterface);
 
 	var map = new MyMap();
-
 
 	var stream = canStreaming.toStream(map.fooList, 'length');
 
@@ -399,8 +421,6 @@ test('Event streams fire change events on a property', function () {
 
 });
 
-
-
 // test('Create a stream from a observable and nested property with shorthand method: toStream', function() {
 
 // 	var expected = 1;
@@ -437,9 +457,6 @@ test('Event streams fire change events on a property', function () {
 // 	obs.foo.bar = 2;
 
 // });
-
-
-
 
 test('Create a stream from a observable and event with shorthand method: toStream', function() {
 	var expected = 0;
@@ -551,8 +568,6 @@ test('Update the list to undefined', function() {
 	expected = undefined;
 	map.fooList = null;
 });
-
-
 
 test("toStreamFromEvent passes event and other arguments", 3, function(){
 	// test by testing toComputeFromEvent first


### PR DESCRIPTION
Exporting the `toStream` function as default so `can-stream` can be used as such:

```
var canStream = require('can-stream');
var compute = require('can-compute');
var someCompute = compute(0);
var streamImplementation = {};
var streamInterface = canStream(streamImplemenation);
streamInterface(someCompute);
```